### PR TITLE
Add On-Premise SDK server, detection_rule, region_strict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # HASS-plate-recognizer
-Read vehicle license plates with https://platerecognizer.com/ which offers free processing of 2500 images per month. You will need to create an account and get your API token.
+Read vehicle license plates with [Plate Recognizer ALPR](https://platerecognizer.com/) which offers free processing of 2500 images per month. You will need to create an account and get your API token.
 
 This integration adds an image processing entity where the state of the entity is the number of license plates found in a processed image. Information about the vehicle which has the license plate is provided in the entity attributes, and includes the license plate number, [region/country](http://docs.platerecognizer.com/#countries), vehicle type, and confidence (in a scale 0 to 1) in this prediction. For each vehicle an `platerecognizer.vehicle_detected` event is fired, containing the same information just listed. Additionally, statistics about your account usage are given in the `Statistics` attribute, including the number of `calls_remaining` out of your 2500 monthly available.
 
 If you have a paid plan that includes MMC (Make/Model/Colour) data you can received the orientation of the vehicle in the entity attributes.
+
+You can also forward the LPR results straight to [ParkPow](https://parkpow.com), a parking management software and sister-company to Plate Recognizer.
+
+If you have a local SDK licence, you can optionally specify the server address.
 
 **Note** this integration does NOT automatically process images, it is necessary to call the `image_processing.scan` service to trigger processing.
 
@@ -24,6 +28,10 @@ image_processing:
     save_timestamped_file: True
     always_save_latest_file: True
     mmc: True
+    detection_rule: strict
+    region: strict
+    server: http://yoururl:8080/v1/plate-reader/
+
     source:
       - entity_id: camera.yours
 ```
@@ -36,6 +44,11 @@ Configuration variables:
 - **save_timestamped_file**: (Optional, default `False`, requires `save_file_folder` to be configured) Save the processed image with the time of detection in the filename.
 - **always_save_latest_file**: (Optional, default `False`, requires `save_file_folder` to be configured) Always save the last processed image, no matter there were detections or not.
 - **mmc**: (Optional, default `False`, requires a [paid plan](https://platerecognizer.com/pricing/) with the MMC (Make, Model, Colour) feature enabled.)  If enabled returns the orientation of the vehicle as a separate attribute containing Front/Rear/Unknown.
+- **detection_rule**: (Optional) If set to `strict`, the license plates that are detected outside a vehicle will be discarded.
+- **region**: (Optional) If set to `strict`, only accept the results that exactly match the templates of the specified region. For example, if the license plate of a region is 3 letters and 3 numbers, the value abc1234 will be discarded. For regions with vanity license plates (e.g. in us-ca), we do not recommend the use of Strict Mode. Otherwise, the engine will discard the vanity plates.
+- **server**: (Optional, requires a [paid plan](https://platerecognizer.com/pricing/) Provide a local server address to use [On-Premise SDK](https://docs.platerecognizer.com/#on-premise-sdk)
+
+
 - **source**: Must be a camera.
 
 <p align="center">


### PR DESCRIPTION
As many people using HA prefer everything to be local, this PR allows specification of a server in the config. Note use of the local SDK requires a paid plan.
Also adds ability to specify the config settings for detection_rule=strict and region=strict as defined at https://docs.platerecognizer.com/#read-number-plates-from-an-image
